### PR TITLE
install_xcode.sh: improved install

### DIFF
--- a/os/os_x/installs/install_xcode.sh
+++ b/os/os_x/installs/install_xcode.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$BASH_SOURCE")" \
 
 main() {
 
-    if ! xcode-select -p &> /dev/null; then
+    if ! xcode-select --print-path &> /dev/null; then
 
         # Prompt user to install the XCode Command Line Tools
         xcode-select --install &> /dev/null
@@ -16,7 +16,7 @@ main() {
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         # Wait until the XCode Command Line Tools are installed
-        while ! xcode-select -p &> /dev/null; do
+        until xcode-select --print-path &> /dev/null; do
             sleep 5
         done
 


### PR DESCRIPTION
Changed the short `-p` to the more verbose `--print-path`. Having short flags in a script isn’t particularly useful. It doesn’t make any relevant difference in speed, but it does make a relevant difference in comprehension.

No need to `while` for a negative result when we have `until`.