### PR TITLE
[osx] Fix trackpad preferences for El Capitan on macbook pro

### DIFF
--- a/src/os/os_x/preferences/set_trackpad_preferences.sh
+++ b/src/os/os_x/preferences/set_trackpad_preferences.sh
@@ -8,12 +8,15 @@ cd "$(dirname "${BASH_SOURCE[0]}")" \
 print_in_purple "\n  Trackpad\n\n"
 
 execute "defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true && \
+         defaults write com.apple.AppleMultitouchTrackpad Clicking -int 1 && \
          defaults write NSGlobalDomain com.apple.mouse.tapBehavior -int 1 && \
          defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1" \
     "Enable 'Tap to click'"
 
 execute "defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightClick -bool true && \
+         defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -int 1 && \
          defaults -currentHost write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true && \
          defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadCornerSecondaryClick -int 0 && \
+         defaults write com.apple.AppleMultitouchTrackpad TrackpadCornerSecondaryClick -int 0 && \
          defaults -currentHost write NSGlobalDomain com.apple.trackpad.trackpadCornerClickBehavior -int 0" \
     "Map 'click or tap with two fingers' to the secondary click"


### PR DESCRIPTION
Use prefix/key com.apple.AppleMultitouchTrackpad for trackpad preferences.

--------------------------------------------------------------------------

See also / Ref:

 * https://github.com/mathiasbynens/dotfiles/pull/612/files