### PR TITLE
[shell] Fix hrfs to add comma to thousand numbers

### DIFF
--- a/src/shell/bash_functions
+++ b/src/shell/bash_functions
@@ -125,9 +125,11 @@ hrfs() {
 
             }
         }' |
-    sed -e ":l; s/\([0-9]\)\([0-9]\{3\}\)/\1,\2/; t l"
-    #                          └─ add commas to the numbers
-    #                             (changes "1023.2 KB" to "1,023.2 KB")
+    sed -e ":l"
+        -e "s/\([0-9]\)\([0-9]\{3\}\)/\1,\2/"
+        -e "t l" #         |
+                 #         └─ add commas to the numbers
+                 #            (changes "1023.2 KB" to "1,023.2 KB")
 }
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Tested it via terminal using below

```bash
$ printf "1234" | sed -e ":l" -e "s/\([0-9]\)\([0-9]\{3\}\)/\1,\2/" -e "t l"
1,234
$ printf "1234" | sed -e ":l s/\([0-9]\)\([0-9]\{3\}\)/\1,\2/;t l"
1234
```