### PR TITLE
Add `/usr/local/sbin` to PATH

### DIFF
--- a/src/shell/bash_profile
+++ b/src/shell/bash_profile
@@ -52,6 +52,14 @@ unset -f source_bash_files
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+# Update path to include shared binaries
+if [[ ":$PATH:" != *":$/usr/local/sbin:"* ]]; then
+    PATH=$PATH:/usr/local/sbin
+    export PATH
+fi
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 # Clear system messages (system copyright notice, the date
 # and time of the last login, the message of the day, etc.).
 


### PR DESCRIPTION
Several utilities (mtr, etc.) install into `/usr/local/sbin`, however, macOS does not automatically include this path.