### PR TITLE
[ubuntu:bash_colors] Prevent overriding custom LS_COLORS

### DIFF
--- a/src/shell/colors/ubuntu/bash_colors
+++ b/src/shell/colors/ubuntu/bash_colors
@@ -29,10 +29,8 @@ export LS_COLORS
 
 if [ -x /usr/bin/dircolors ]; then
 
-    if test -r ~/.dircolorS; then
+    if test -r ~/.dircolors; then
         eval "$(dircolors -b ~/.dircolors)"
-    else
-        eval "$(dircolors -b)"
     fi
 
     alias dir="dir --color=auto"


### PR DESCRIPTION
Fixes #51.

Use `~/.dircolors` if it is available, else use the custom `LS_COLORS` value.