### PR TITLE
Remove duplicate code execution (macOS AutoCorrect)

### DIFF
--- a/src/os/preferences/macos/language_and_region.sh
+++ b/src/os/preferences/macos/language_and_region.sh
@@ -12,6 +12,3 @@ execute "defaults write -g AppleLanguages -array 'en'" \
 
 execute "defaults write -g AppleMeasurementUnits -string 'Centimeters'" \
     "Set measurement units"
-
-execute "defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false" \
-    "Disable auto-correct"


### PR DESCRIPTION
Remove the following command

`defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false`

from language_and_region.sh as it is already called in [keyboard.sh#L25](https://github.com/alrra/dotfiles/blob/9473942b46c9aab046e8a4083653cfe762d910c3/src/os/preferences/macos/keyboard.sh#L25)

Fixes #74 