### PR TITLE
✨ Install youtube-dl on macOS

### DIFF
--- a/src/os/install/macos/video_tools.sh
+++ b/src/os/install/macos/video_tools.sh
@@ -10,3 +10,4 @@ print_in_purple "\n   Video Tools\n\n"
 
 brew_install "AtomicParsley" "atomicparsley"
 brew_install "FFmpeg" "ffmpeg"
+brew_install "youtube-dl" "youtube-dl"


### PR DESCRIPTION
See: https://github.blog/2020-11-16-standing-up-for-developers-youtube-dl-is-back/

This reverts commit 94c3a3d5f69d57c28f9f2105fa9ce5c9e47cb757.

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>